### PR TITLE
change path to match production path on generic admin node

### DIFF
--- a/branches/bugzilla/config.ini
+++ b/branches/bugzilla/config.ini
@@ -22,7 +22,7 @@ feed_timeout = 20
 # output_dir: Directory to place output files
 # items_per_page: How many items to put on each page
 output_theme = moz_bugzilla
-output_dir = /data/static/src/planet.bugzilla.org
+output_dir = /data/genericrhel6/src/planet.bugzilla.org
 items_per_page = 75
 
 # If non-zero, all feeds which have not been updated in the indicated

--- a/branches/bugzilla/theme/config.ini
+++ b/branches/bugzilla/theme/config.ini
@@ -8,7 +8,7 @@ template_files:
   rss20.xml.tmpl
 
 template_directories:
-  ../../../trunk/themes/common
+  ../../../../planet-source/trunk/themes/common/
 
 bill_of_materials:
   .htaccess


### PR DESCRIPTION
Hey @mhoye,

At some point in the past, the other Planets were updated with a slightly modified `template_directories` path in the `theme/config.ini` file. Here's an example:

https://github.com/mozilla/planet-content/blob/62c1ab9ef194166aab19276ef02d6c01276922bf/branches/ateam/theme/config.ini

Looking at the logs, I think new updates for planet.bugzilla.org are throwing an error because they cannot find the `atom.xml.xslt` file. I believe this will fix that.