### PR TITLE
Update William Lachance's feed to use https uri

### DIFF
--- a/branches/planet/config.ini
+++ b/branches/planet/config.ini
@@ -440,7 +440,7 @@ name = Shane Tomlinson
 [http://globau.wordpress.com/category/mozilla/feed/]
 name = Byron Jones
 
-[http://wlach.github.io/feeds/Mozilla.rss.xml]
+[https://wlach.github.io/feeds/Mozilla.rss.xml]
 name = William Lachance
 
 [https://blog.mozilla.org/nfroyd/feed/]


### PR DESCRIPTION
My blog is set to enforce https, so this avoids a redirect and hopefully fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1423921