### PR TITLE
https all the things (where appropriate)

### DIFF
--- a/branches/bugzilla/config.ini
+++ b/branches/bugzilla/config.ini
@@ -7,7 +7,7 @@
 # owner_name: Your name
 # owner_email: Your e-mail address
 name = Planet Bugzilla
-link = http://planet.bugzilla.org
+link = https://planet.bugzilla.org
 owner_name = Bugzilla Webmasters
 owner_email = webmaster@bugzilla.org
 
@@ -68,10 +68,10 @@ faceheight = 85
 # "natively" knows about.  Look at fancy-examples/index.html.tmpl
 # for the flip-side of this.
 
-[http://bugzillaupdate.wordpress.com/feed/atom/]
+[https://bugzillaupdate.wordpress.com/feed/atom/]
 name = Bugzilla Update
 
-[http://bugzillatips.wordpress.com/feed/atom/]
+[https://bugzillatips.wordpress.com/feed/atom/]
 name = Bugzilla Tips
 
 [https://mrcote.info//blog/categories/bugzilla/atom.xml]
@@ -80,12 +80,12 @@ name = Mark Côté
 [https://dylanwh.tumblr.com/rss]
 name = Dylan Hardison
 
-[http://blog.gerv.net/category/bugzilla/feed/]
+[https://blog.gerv.net/category/bugzilla/feed/]
 name = Gervase Markham
 
-[http://www.justdave.net/dave/category/bugzilla/feed/]
+[https://www.justdave.net/dave/category/bugzilla/feed/]
 name = David Miller
 
-[http://blog.fedora-fr.org/eseyman/feed/tag/bugzilla/atom]
+[https://blog.fedora-fr.org/eseyman/feed/tag/bugzilla/atom]
 name = Emmanuel Seyman
 

--- a/branches/bugzilla/theme/index.html.tmpl
+++ b/branches/bugzilla/theme/index.html.tmpl
@@ -16,7 +16,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <meta name="generator" content="<TMPL_VAR generator ESCAPE="HTML">">
 <link rel="stylesheet" href="planet.css" type="text/css">
-<link rel="icon" href="http://www.mozilla.org/images/mozilla-16.png" type="image/png">
+<link rel="icon" href="https://www.bugzilla.org/img/bugzilla_icon.png" type="image/png">
 <TMPL_IF feedtype>
 <link rel="alternate" href="<TMPL_VAR feed ESCAPE="HTML">" title="<TMPL_VAR channel_title_plain ESCAPE="HTML">" type="application/<TMPL_VAR feedtype>+xml">
 </TMPL_IF>
@@ -90,11 +90,11 @@ You can also follow a number of our contributors (some of whom don't blog) <a hr
 
   <div id="footer">
    <ul id="bn">
-    <li><a href="http://www.mozillafoundation.org/">Mozilla Foundation</a></li>
+    <li><a href="https://www.mozillafoundation.org/">Mozilla Foundation</a></li>
     <li><a href="http://www.mozillazine.org/">MozillaZine.org</a></li>
-    <li><a href="http://www.mozilla.org/get-involved.html">Get Involved!</a></li>
+    <li><a href="https://www.mozilla.org/get-involved.html">Get Involved!</a></li>
    </ul>
-   <p>Maintained by <a href="mailto:<TMPL_VAR owner_email>"><TMPL_VAR owner_name></a>, powered by <a href="http://www.intertwingly.net/code/venus/">Planet Venus</a></p>
+   <p>Maintained by <a href="mailto:<TMPL_VAR owner_email>"><TMPL_VAR owner_name></a>, powered by <a href="https://www.intertwingly.net/code/venus/">Planet Venus</a></p>
   </div>
 </body>
 

--- a/branches/bugzilla/theme/index.html.tmpl
+++ b/branches/bugzilla/theme/index.html.tmpl
@@ -91,7 +91,6 @@ You can also follow a number of our contributors (some of whom don't blog) <a hr
   <div id="footer">
    <ul id="bn">
     <li><a href="https://www.mozillafoundation.org/">Mozilla Foundation</a></li>
-    <li><a href="http://www.mozillazine.org/">MozillaZine.org</a></li>
     <li><a href="https://www.mozilla.org/get-involved.html">Get Involved!</a></li>
    </ul>
    <p>Maintained by <a href="mailto:<TMPL_VAR owner_email>"><TMPL_VAR owner_name></a>, powered by <a href="https://www.intertwingly.net/code/venus/">Planet Venus</a></p>


### PR DESCRIPTION
Noticed an insecure content warning looking at Planet Bugzilla, and it turned out it was embedded images in our own template, not in the content, causing it.  Updated the template and the feed config to use https for everything that actually supports it.