### PR TITLE
Improve big image styling & avoid horizontal scrolling

### DIFF
--- a/branches/planet/theme/planet.css
+++ b/branches/planet/theme/planet.css
@@ -1,6 +1,7 @@
 * {
   line-height: 1.4;
   padding: 0;
+  max-width: 100%;
 }
 
 ul,
@@ -132,7 +133,7 @@ h4 a {
   text-align: right;
 }
 
-.news img {max-width:100% !important;}
+.news img {max-width:100% !important; height: auto;}
 
 #footer {
   background-image: url('img/footer.jpg');


### PR DESCRIPTION
At the moment, the Planet Mozilla page can require a lot of horizontal scrolling because it elements have very wide widths specified.  So add max-width: 100% to everything to avoid this. 

An img that has its width limited will end up with a bad height, so add height: auto too.

Compare

![Screenshot from 2020-11-15 16-46-56](https://user-images.githubusercontent.com/405490/99189632-76e61300-2762-11eb-9a7c-a4a94e65c23a.png)

![Screenshot from 2020-11-15 16-48-39](https://user-images.githubusercontent.com/405490/99189634-78174000-2762-11eb-923f-93c11739434d.png)