### PR TITLE
Bug 1684198 - Remove defunct rumblingedge.com from Planet Thunderbird.

### DIFF
--- a/branches/thunderbird/config.ini
+++ b/branches/thunderbird/config.ini
@@ -98,9 +98,6 @@ face = http://gozer.ectoplasm.org/images/gozer-gochi-small.png
 [http://home.kairo.at/?d=w&i=1&m=v&c=atom&f.lang=en]
 name = Robert Kaiser
 
-[http://feeds.feedburner.com/rumblingedge]
-name = Rumbling Edge - Thunderbird
-
 [http://thunderbird-l10n.blogspot.com/feeds/posts/default]
 name = Thunderbird Localization
 


### PR DESCRIPTION
This domain isn't maintained any longer and seems to be feeding spam into Planet, see https://bugzilla.mozilla.org/show_bug.cgi?id=1684198