### PR TITLE
Remove 404 feed found in deploy logs.

### DIFF
--- a/branches/bugzilla/config.ini
+++ b/branches/bugzilla/config.ini
@@ -74,9 +74,6 @@ name = Bugzilla Update
 [https://bugzillatips.wordpress.com/feed/atom/]
 name = Bugzilla Tips
 
-[https://mrcote.info//blog/categories/bugzilla/atom.xml]
-name = Mark Côté
-
 [https://dylanwh.tumblr.com/rss]
 name = Dylan Hardison
 


### PR DESCRIPTION
While reviewing deploy logs for planet, I noticed this:

$ python planet.py configs/bugzilla.ini
ERROR:planet.runner:Error 404 while updating feed https://mrcote.info//blog/categories/bugzilla/atom.xml

That blog no longer has category URL support, and hasn't updated since 2019, so duly suggested for removal.